### PR TITLE
Code Cleanup, relocation "run" button

### DIFF
--- a/SSR Visualizer/SSRWindow.py
+++ b/SSR Visualizer/SSRWindow.py
@@ -9,17 +9,13 @@ class QTextEditLogger(QtCore.QObject):
     """A logger that writes to a QTextEdit widget."""
     def __init__(self, text_edit):
         super().__init__()
-        self.text_edit = text_edit
+        self.text_edit= text_edit
 
     def write(self, msg):
         """Write a message to the QTextEdit widget."""
         if msg.strip():
             self.text_edit.append(msg)
             self.text_edit.moveCursor(QtGui.QTextCursor.End)
-
-    def flush(self):
-        """Flush method to comply with file-like interface."""
-        pass
 
 
 class SSRPointerWindow(QtWidgets.QWidget):
@@ -30,125 +26,147 @@ class SSRPointerWindow(QtWidgets.QWidget):
     Usage:
         To Do
     """
-    def __init__ ( self, parent=None ):
+    def __init__ (self, parent=None):
         """
         Initializes the SSR Pointer Tool window and its widgets.
         Widgets and layout:
-            - Run SSR Pointer Tool button (row 0, columns 0-3): Starts the SSR pointer visualization.
+            - Run SSR Pointer Tool button (row 0, columns 0-3): Starts the
+              SSR pointer visualization.
             - Image output area (row 1, columns 0-3): Displays generated SSR pointer plots.
-            - SSR Selection Combo Box (row 2, columns 0-3): Allows selection between SSR-A and SSR-B pointer sets.
+            - SSR Selection Combo Box (row 2, columns 0-3): Allows selection between
+              SSR-A and SSR-B pointer sets.
             - Console output area (row 2, columns 0-3): Shows log and console messages.
             - Quit button (row 3, column 3): Closes the interface.
             - Additional read-only text display for formatted output.
         Note:
-            The widgets are arranged using a QGridLayout, with most controls spanning all columns for a wide interface.
+            The widgets are arranged using a QGridLayout, with most controls spanning all
+            columns for a wide interface.
         """
         QtWidgets.QWidget.__init__(self,parent)
-        self.redBackground =  "QPushButton { background: red }"
+        self.redBackground=   "QPushButton { background: red }"
         self.greenBackground= "QPushButton { background: lightgreen }"
         self.setWindowTitle ("SSR Pointer Tool (Ver 1.0)")
         self.resize(QtCore.QSize(800,1100))
         self.layout= QtWidgets.QGridLayout()
+        self.selectedssr= None
+        self.plot_path= None
         self.plot= None
 
 #       # Build GUI
-        self.build_run_button()    # row 0, columns 0-3
-        self.build_ssr_selection() # row 1, columns 0-3
-        self.build_image_output()  # row 2, columns 0-3
-        self.build_console()       # row 3, columns 0-3
-        self.build_quit_button()   # row 4, column 3
-        self.gui_formatting()
+        build_ssr_selection(self) # row 1, columns 0-3
+        build_image_output(self)  # row 2, columns 0-3
+        build_console(self)       # row 3, columns 0-3
+        build_run_button(self)    # row 4, columns 0-2
+        build_quit_button(self)   # row 4, column 3
+        gui_formatting(self)
 
         # Button clicked actions
-        self.runSSRButton.clicked.connect(self.runSSR)
-        self.quitButton.clicked.connect(self.quitSlot)
+        self.runssrbutton.clicked.connect(self.run_ssr)
+        self.quitbutton.clicked.connect(self.quit_event)
 
-    def build_run_button(self):
-        "build the run button"
-        self.runSSRButton = QtWidgets.QPushButton("Run SSR Pointer Tool")
-        self.runSSRButton.setToolTip("Run the SSR Pointer Tool to generate a plot of SSR pointers")
-        self.runSSRButton.setMinimumHeight(40)
-        runFont= self.runSSRButton.font()
-        runFont.setBold(True)
-        runFont.setPointSize(2 * runFont.pointSize())
-        self.runSSRButton.setFont(runFont)
-        self.runSSRButton.setStyleSheet(self.greenBackground)
-        self.layout.addWidget(self.runSSRButton, 0, 0, 1, 4)
+    def selected_ssr(self, text):
+        "Handle changes in the SSR selection combo box."
+        self.selectedssr= text
 
-    def build_ssr_selection(self):
-        "build the SSR selection combo box"
-        # Section label
-        self.ssrLabel = QtWidgets.QLabel("Select SSR:")
-        self.ssrLabel.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
-        self.ssrLabel.setMinimumHeight(30)
-        self.layout.addWidget(self.ssrLabel, 1, 0, 1, 1)
-
-        # SSR selection combo box
-        self.ssrComboBox = QtWidgets.QComboBox()
-        self.ssrComboBox.addItems(["A", "B"])
-        self.ssrComboBox.setToolTip("Select an SSR pointer set to visualize")
-        self.ssrComboBox.setMinimumHeight(30)
-        self.layout.addWidget(self.ssrComboBox, 1, 1, 1, 2)
-        self.selectedSSR = self.ssrComboBox.currentText()
-        self.ssrComboBox.currentTextChanged.connect(self.onSSRChanged)
-
-    def build_image_output(self):
-        "build the image output area"
-        self.imageOutput = QtWidgets.QLabel()
-        self.imageOutput.setAlignment(QtCore.Qt.AlignCenter)
-        self.imageOutput.setMinimumHeight(int(self.height() * 0.70))
-        self.imageOutput.setStyleSheet("border: 1px solid gray; background: #f0f0f0;")
-        if self.plot is not None:
-            self.imageOutput.setPixmap(
-                QtGui.QPixmap(self.plot_path).scaled(int(self.height() * 0.70),
-                                                               int(self.height() * 0.70)))
-        self.layout.addWidget(self.imageOutput, 2, 0, 1, 4)
-
-    def build_console(self):
-        "build the console output area"
-        self.consoleOutput= QtWidgets.QTextEdit()
-        self.consoleOutput.setReadOnly(True)
-        self.consoleOutput.setLineWrapMode(QtWidgets.QTextEdit.NoWrap)
-        self.consoleOutput.setFont(QtGui.QFont("Courier", 10))
-        self.consoleOutput.setMinimumHeight(int(self.height() * 0.10))
-        self.layout.addWidget(self.consoleOutput, 3, 0, 1, 4)
-        sys.stdout= QTextEditLogger(self.consoleOutput)
-        sys.stderr= QTextEditLogger(self.consoleOutput)
-
-    def build_quit_button(self):
-        "build the quit button"
-        self.quitButton = QtWidgets.QPushButton('Quit')
-        self.quitButton.setToolTip('Close New Beat Interface')
-        self.quitButton.setStyleSheet(self.redBackground)
-        self.layout.addWidget(self.quitButton, 4, 3)
-
-    def gui_formatting(self):
-        "formatting for the GUI"
-        self.textDisplay = QtWidgets.QTextEdit()
-        self.textDisplay.setReadOnly ( True )
-        self.textDisplay.setLineWrapMode(QtWidgets.QTextEdit.NoWrap)
-        self.textDisplay.moveCursor (QtGui.QTextCursor.End)
-        font = QtGui.QFont ("Courier", 10, QtGui.QFont.Bold)
-        self.textDisplay.setFont (font)
-        self.setLayout(self.layout)
-
-    def onSSRChanged(self, text):
-        """Handle changes in the SSR selection combo box."""
-        self.selectedSSR = text
-
-    def runSSR(self):
+    def run_ssr(self):
+        "Handle the Run button click event"
         self.plot= generate_image(self)
 
         if self.plot is not None:
             with NamedTemporaryFile(suffix= ".jpg", delete= False) as tmp_file:
                 self.plot_path= tmp_file.name
                 self.plot.write_image(self.plot_path, scale=2)
-            self.build_image_output()
+            build_image_output(self)
             os.remove(tmp_file.name)
         else:
-            self.build_image_output()
-            print(f"  - SSR-{self.selectedSSR} is OFF, cannot generate plot.\n")
+            build_image_output(self)
+            print(f"  - SSR-{self.selectedssr} is OFF, cannot generate plot.\n")
 
-    def quitSlot(self):
-        """Handle the quit button click event."""
+    def quit_event(self):
+        "Handle the quit button click event."
         sys.exit(1)
+
+
+def build_run_button(self):
+    "build the run button"
+    self.runssrbutton= QtWidgets.QPushButton("Run SSR Pointer Tool")
+    self.runssrbutton.setToolTip("Run the SSR Pointer Tool to generate a plot of SSR pointers")
+    self.runssrbutton.setMinimumHeight(40)
+    runfont= self.runssrbutton.font()
+    runfont.setBold(True)
+    runfont.setPointSize(2 * runfont.pointSize())
+    self.runssrbutton.setFont(runfont)
+    self.runssrbutton.setStyleSheet(self.greenBackground)
+    self.layout.addWidget(self.runssrbutton, 4, 0, 1, 3)
+
+
+def build_ssr_selection(self):
+    "build the SSR selection combo box"
+    # Section label
+    self.ssrlabel= QtWidgets.QLabel("Select SSR:")
+    self.ssrlabel.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignCenter)
+    self.ssrlabel.setMinimumHeight(30)
+    ssrfont= self.ssrlabel.font()
+    ssrfont.setPointSize(2 * ssrfont.pointSize())
+    self.ssrlabel.setFont(ssrfont)
+    self.layout.addWidget(self.ssrlabel, 1, 0)
+
+    # SSR selection combo box
+    self.ssrcombobox= QtWidgets.QComboBox()
+    self.ssrcombobox.addItems(["A", "B"])
+    self.ssrcombobox.setEditable(True)
+    self.ssrcombobox.setToolTip("Select an SSR pointer set to visualize")
+    line_edit= self.ssrcombobox.lineEdit() # Move selectable items to center of box
+    line_edit.setAlignment(QtCore.Qt.AlignCenter)
+    line_edit.setReadOnly(True)
+    self.ssrcombobox.setMinimumHeight(30)
+    ssrcombofont= self.ssrcombobox.font()
+    ssrcombofont.setPointSize(2 * ssrcombofont.pointSize())
+    self.ssrcombobox.setFont(ssrcombofont)
+    self.layout.addWidget(self.ssrcombobox, 1, 1)
+    self.selectedssr= self.ssrcombobox.currentText()
+    self.ssrcombobox.currentTextChanged.connect(self.selected_ssr)
+
+
+def build_image_output(self):
+    "build the image output area"
+    self.imageoutput= QtWidgets.QLabel()
+    self.imageoutput.setAlignment(QtCore.Qt.AlignCenter)
+    self.imageoutput.setMinimumHeight(int(self.height() * 0.70))
+    self.imageoutput.setStyleSheet("border: 1px solid gray; background: #f0f0f0;")
+    if self.plot is not None:
+        self.imageoutput.setPixmap(
+            QtGui.QPixmap(self.plot_path).scaled(int(self.height() * 0.70),
+                                                    int(self.height() * 0.70)))
+    self.layout.addWidget(self.imageoutput, 2, 0, 1, 4)
+
+
+def build_console(self):
+    "build the console output area"
+    self.consolequtput= QtWidgets.QTextEdit()
+    self.consolequtput.setReadOnly(True)
+    self.consolequtput.setLineWrapMode(QtWidgets.QTextEdit.NoWrap)
+    self.consolequtput.setFont(QtGui.QFont("Courier", 10))
+    self.consolequtput.setMinimumHeight(int(self.height() * 0.10))
+    self.layout.addWidget(self.consolequtput, 3, 0, 1, 4)
+    sys.stdout= QTextEditLogger(self.consolequtput)
+    sys.stderr= QTextEditLogger(self.consolequtput)
+
+
+def build_quit_button(self):
+    "build the quit button"
+    self.quitbutton= QtWidgets.QPushButton('Quit')
+    self.quitbutton.setToolTip('Close New Beat Interface')
+    self.quitbutton.setStyleSheet(self.redBackground)
+    self.layout.addWidget(self.quitbutton, 4, 3)
+
+
+def gui_formatting(self):
+    "formatting for the GUI"
+    self.textdisplay= QtWidgets.QTextEdit()
+    self.textdisplay.setReadOnly ( True )
+    self.textdisplay.setLineWrapMode(QtWidgets.QTextEdit.NoWrap)
+    self.textdisplay.moveCursor (QtGui.QTextCursor.End)
+    font= QtGui.QFont("Courier", 10, QtGui.QFont.Bold)
+    self.textdisplay.setFont (font)
+    self.setLayout(self.layout)

--- a/SSR Visualizer/generate_image.py
+++ b/SSR Visualizer/generate_image.py
@@ -203,17 +203,17 @@ def generate_image(self):
     """
     start_date= datetime.now(timezone.utc) - timedelta(hours= 18.5)
     end_date=   datetime.now(timezone.utc) - timedelta(seconds=5)
-    ssr_power=  data_request(start_date, end_date, f"COSSR{self.selectedSSR}X", skip= True)
-    print(f"Checking if SSR-{self.selectedSSR} is ON...")
+    ssr_power=  data_request(start_date, end_date, f"COSSR{self.selectedssr}X", skip= True)
+    print(f"Checking if SSR-{self.selectedssr} is ON...")
 
     # Only generate plot if SSR is ON
     try:
         if int(ssr_power['data-fmt-1']['values'][-1]) == 1:
-            print(f"  - SSR-{self.selectedSSR} is ON...")
-            pb_pointers, rc_pointer= get_pointers(start_date, end_date, self.selectedSSR)
-            plot= generate_polar_plot(self.selectedSSR, pb_pointers, rc_pointer)
+            print(f"  - SSR-{self.selectedssr} is ON...")
+            pb_pointers, rc_pointer= get_pointers(start_date, end_date, self.selectedssr)
+            plot= generate_polar_plot(self.selectedssr, pb_pointers, rc_pointer)
             return plot
     except IndexError as error:
-        print(f""" - (Error) "{error}": Unable to retrieve SSR-{self.selectedSSR} power data.""")
+        print(f""" - (Error) "{error}": Unable to retrieve SSR-{self.selectedssr} power data.""")
         traceback.print_exc()
     return None


### PR DESCRIPTION
Clean up bad variable names and method locations.
Relocation "Run" button to bottom of GUI.
Modify formating of "Select SSR" Section.